### PR TITLE
PSR-1451 Optional response

### DIFF
--- a/app/uk/gov/hmrc/pensionschemereturnsipp/controllers/SippPsrSubmitController.scala
+++ b/app/uk/gov/hmrc/pensionschemereturnsipp/controllers/SippPsrSubmitController.scala
@@ -24,6 +24,7 @@ import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.http.{BadRequestException, HttpErrorFunctions}
 import uk.gov.hmrc.pensionschemereturnsipp.auth.PsrAuth
 import uk.gov.hmrc.pensionschemereturnsipp.models.JourneyType
+import uk.gov.hmrc.pensionschemereturnsipp.models.api.common.OptionalResponse
 import uk.gov.hmrc.pensionschemereturnsipp.models.api.{
   PsrSubmissionRequest,
   PsrSubmittedResponse,
@@ -206,7 +207,8 @@ class SippPsrSubmitController @Inject()(
       )
       sippPsrSubmissionService.getPsrAssetsExistence(pstr, optFbNumber, optPeriodStartDate, optPsrVersion).map {
         case Left(_) => NotFound
-        case Right(sippPsrSubmission) => Ok(Json.toJson(sippPsrSubmission))
+        case Right(sippPsrSubmission) =>
+          Ok(Json.toJson(OptionalResponse(sippPsrSubmission))(OptionalResponse.formatter()))
       }
     }
   }

--- a/app/uk/gov/hmrc/pensionschemereturnsipp/models/api/common/OptionalResponse.scala
+++ b/app/uk/gov/hmrc/pensionschemereturnsipp/models/api/common/OptionalResponse.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pensionschemereturnsipp.models.api.common
+
+import play.api.libs.json.{Format, Json, OFormat}
+
+case class OptionalResponse[Response](
+  response: Option[Response]
+)
+
+object OptionalResponse {
+  def formatter[Response]()(implicit responseFormat: Format[Response]): OFormat[OptionalResponse[Response]] =
+    Json.format[OptionalResponse[Response]]
+}

--- a/test/uk/gov/hmrc/pensionschemereturnsipp/controllers/SippPsrSubmitControllerSpec.scala
+++ b/test/uk/gov/hmrc/pensionschemereturnsipp/controllers/SippPsrSubmitControllerSpec.scala
@@ -30,6 +30,8 @@ import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.{~, Name}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pensionschemereturnsipp.models.JourneyType.Standard
+import uk.gov.hmrc.pensionschemereturnsipp.models.api.PsrAssetCountsResponse
+import uk.gov.hmrc.pensionschemereturnsipp.models.api.common.OptionalResponse
 import uk.gov.hmrc.pensionschemereturnsipp.models.etmp.PersonalDetails
 import uk.gov.hmrc.pensionschemereturnsipp.services.SippPsrSubmissionService
 import uk.gov.hmrc.pensionschemereturnsipp.utils.{BaseSpec, TestValues}
@@ -232,6 +234,9 @@ class SippPsrSubmitControllerSpec extends BaseSpec with TestValues {
 
       val result = controller.getPsrAssetsExistence("testPstr", Some("fbNumber"), None, None)(fakeRequest)
       status(result) mustBe Status.OK
+
+      val response = contentAsJson(result).as[OptionalResponse[PsrAssetCountsResponse]](OptionalResponse.formatter())
+      response.response mustBe Some(samplePsrAssetsExistenceResponse)
     }
 
     "return 200 when the PSR exists but has no members or transactions" in {
@@ -246,6 +251,8 @@ class SippPsrSubmitControllerSpec extends BaseSpec with TestValues {
       val result =
         controller.getPsrAssetsExistence("testPstr", None, Some("periodStartDate"), Some("version"))(fakeRequest)
       status(result) mustBe Status.OK
+      val response = contentAsJson(result).as[OptionalResponse[PsrAssetCountsResponse]](OptionalResponse.formatter())
+      response.response mustBe None
     }
 
     "return 404 when the PSR does not exist" in {


### PR DESCRIPTION
By default the hmrc http formats convert 404s to None - this change allows for a response to be successful but have an optional payload (wrapper)