### PR TITLE
PSR-1780 BUGFIX incorrect update status

### DIFF
--- a/app/uk/gov/hmrc/pensionschemereturnsipp/services/SippPsrSubmissionService.scala
+++ b/app/uk/gov/hmrc/pensionschemereturnsipp/services/SippPsrSubmissionService.scala
@@ -717,7 +717,7 @@ class SippPsrSubmissionService @Inject() (
           val updateRequest = SippPsrSubmissionEtmpRequest(
             reportDetails = response.reportDetails
               .copy(status = EtmpPsrStatus.Compiled, version = None)
-              .withAssetClassDeclaration(journey, declaration = YesNo.No.some),
+              .withAssetClassDeclaration(journey, declaration = None),
             accountingPeriodDetails = response.accountingPeriodDetails,
             memberAndTransactions = updatedMembers,
             psrDeclaration = response.psrDeclaration.map(declaration =>

--- a/test/uk/gov/hmrc/pensionschemereturnsipp/services/SippPsrSubmissionServiceSpec.scala
+++ b/test/uk/gov/hmrc/pensionschemereturnsipp/services/SippPsrSubmissionServiceSpec.scala
@@ -1350,7 +1350,7 @@ class SippPsrSubmissionServiceSpec extends BaseSpec with TestValues with SippEtm
             mockitoEq(
               SippPsrSubmissionEtmpRequest(
                 reportDetails =
-                  sampleResponse.reportDetails.copy(version = None).withAssetClassDeclaration(journey, Some(YesNo.No)),
+                  sampleResponse.reportDetails.copy(version = None).withAssetClassDeclaration(journey, None),
                 accountingPeriodDetails = None,
                 memberAndTransactions = Some(
                   NonEmptyList.one(
@@ -1440,7 +1440,7 @@ class SippPsrSubmissionServiceSpec extends BaseSpec with TestValues with SippEtm
             SippPsrSubmissionEtmpRequest(
               reportDetails = sampleResponse.reportDetails
                 .copy(version = None)
-                .withAssetClassDeclaration(Journey.InterestInLandOrProperty, Some(YesNo.No)),
+                .withAssetClassDeclaration(Journey.InterestInLandOrProperty, None),
               accountingPeriodDetails = None,
               memberAndTransactions = Some(
                 NonEmptyList.one(


### PR DESCRIPTION
The frontend logic to decide whether or not an asset has been updated relies on this flag being set to None.

Please see [here](https://github.com/hmrc/pension-scheme-return-sipp-frontend/blob/01e4348e431b188033522ad4623da48382e49d37/app/services/view/TaskListViewModelService.scala#L401) how the frontend uses this flag